### PR TITLE
Add Loads for UH-60L, Mi-24P, "AH-64D_BLK_II

### DIFF
--- a/CSAR.lua
+++ b/CSAR.lua
@@ -28,6 +28,9 @@ csar.aircraftType["Mi-8MT"] = 16
 csar.aircraftType["UH-60L"] = 11
 csar.aircraftType["Mi-24P"] = 8
 csar.aircraftType["AH-64D_BLK_II"] = 2
+csar.aircraftType["OH58D"] = 2
+csar.aircraftType["CH-47Fbl1"] = 2
+csar.aircraftType["OH-6A"] = 4
 
 -- Prefix Settings - Only For helicopters
 csar.useprefix    = true  -- Use the Prefixed defined below, Requires Unit have the Prefix defined below 

--- a/CSAR.lua
+++ b/CSAR.lua
@@ -25,6 +25,9 @@ csar.aircraftType["SA342L"] = 2
 csar.aircraftType["SA342M"] = 2
 csar.aircraftType["UH-1H"] = 8
 csar.aircraftType["Mi-8MT"] = 16
+csar.aircraftType["UH-60L"] = 11
+csar.aircraftType["Mi-24P"] = 8
+csar.aircraftType["AH-64D_BLK_II"] = 2
 
 -- Prefix Settings - Only For helicopters
 csar.useprefix    = true  -- Use the Prefixed defined below, Requires Unit have the Prefix defined below 


### PR DESCRIPTION
Just updating for new aircraft.  Apache can fit 2 extra on-side pods with straps https://qph.cf2.quoracdn.net/main-qimg-14843e885e1e7d5f78b0cca825b824e4-lq https://qph.cf2.quoracdn.net/main-qimg-35c1e30914549bc55562d22da69ad5be-lq