### PR TITLE
Changed the beacons radio transmissions

### DIFF
--- a/CSAR.lua
+++ b/CSAR.lua
@@ -943,7 +943,11 @@ function csar.heightDiff(_unit)
     return _point.y - land.getHeight({ x = _point.x, y = _point.z })
 end
 
-function csar.stopBeaconIfNeeded(_woundedGroupName, _freq)
+function csar.stopBeaconIfNeeded(parameters)
+    csar.logDebug(string.format("csar.stopBeaconIfNeeded(parameters=%s)", csar.p(parameters)))
+    local _woundedGroupName, _freq = unpack(parameters)
+    csar.logDebug(string.format("csar.stopBeaconIfNeeded(_woundedGroupName=%s, _freq=%s)", csar.p(_woundedGroupName), csar.p(_freq)))
+
     local _group = Group.getByName(_woundedGroupName)
 
     
@@ -971,6 +975,7 @@ function csar.stopBeaconIfNeeded(_woundedGroupName, _freq)
 end
 
 csar.addBeaconToGroup = function(_woundedGroupName, _freq)
+    csar.logDebug(string.format("csar.addBeaconToGroup(_woundedGroupName=%s, _freq=%s)", csar.p(_woundedGroupName), csar.p(_freq)))
 
     local _group = Group.getByName(_woundedGroupName)
 
@@ -983,7 +988,7 @@ csar.addBeaconToGroup = function(_woundedGroupName, _freq)
         trigger.action.radioTransmission(_sound, _group:getUnit(1):getPoint(), 0, true, _freq, 1000, _vhfBeaconName)
 
         -- call the function that will stop the beacon when the group is destroyed or rescued; it'll reschedule itself
-        csar.stopBeaconIfNeeded(_woundedGroupName, _freq)
+        csar.stopBeaconIfNeeded({_woundedGroupName, _freq})
     end
 
 end
@@ -1957,7 +1962,7 @@ function csar.addMedevacMenuItem()
         end
       end
     end
-    
+
     for key, unitName in pairs(csar.csarFixedUnits) do
       if csar.csarUnits[unitName] == nil then
         csar.csarUnits[unitName] = unitName
@@ -1969,7 +1974,7 @@ function csar.addMedevacMenuItem()
         end
       end
     end
-    
+
     for _, _unitName in pairs(csar.csarUnits) do
 
         local _unit = csar.getSARHeli(_unitName)
@@ -2214,27 +2219,27 @@ function csar.initialize(force)
         return
     end
 
-csar.generateVHFrequencies()
+    csar.generateVHFrequencies()
 
--- Schedule timer to add radio item
-timer.scheduleFunction(csar.addMedevacMenuItem, nil, timer.getTime() + 5)
+    -- Schedule timer to add radio item
+    timer.scheduleFunction(csar.addMedevacMenuItem, nil, timer.getTime() + 5)
 
-if csar.disableAircraftTimeout then
-    -- Schedule timer to reactivate things
-    timer.scheduleFunction(csar.reactivateAircraft, nil, timer.getTime() + 5)
-end
+    if csar.disableAircraftTimeout then
+        -- Schedule timer to reactivate things
+        timer.scheduleFunction(csar.reactivateAircraft, nil, timer.getTime() + 5)
+    end
 
-world.addEventHandler(csar.eventHandler)
+    world.addEventHandler(csar.eventHandler)
 
     csar.logInfo("CSAR event handler added")
 
---save CSAR MODE
-trigger.action.setUserFlag("CSAR_MODE", csar.csarMode)
+    --save CSAR MODE
+    trigger.action.setUserFlag("CSAR_MODE", csar.csarMode)
 
--- disable aircraft
-if csar.enableSlotBlocking then
+    -- disable aircraft
+    if csar.enableSlotBlocking then
 
-    trigger.action.setUserFlag("CSAR_SLOTBLOCK", 100)
+        trigger.action.setUserFlag("CSAR_SLOTBLOCK", 100)
 
         csar.logInfo("CSAR Slot block enabled")
     end

--- a/CSAR.lua
+++ b/CSAR.lua
@@ -1962,7 +1962,7 @@ function csar.addMedevacMenuItem()
       if csar.csarUnits[unitName] == nil then
         csar.csarUnits[unitName] = unitName
         for _woundedName, _groupInfo in pairs(csar.woundedGroups) do
-          if _groupInfo.side == _group:getCoalition() then
+          if false --[[ _group is nil here, can't ever work (see my comment https://github.com/ciribob/DCS-CSAR/commit/907524d1e97930061d5f32832523bc4f7455192d#commitcomment-126043845) _groupInfo.side == _group:getCoalition() ]] then
             -- Schedule timer to check when to pop smoke
               timer.scheduleFunction(csar.checkWoundedGroupStatus, { unitName , _woundedName }, timer.getTime() + 5)
            end

--- a/CSAR.lua
+++ b/CSAR.lua
@@ -476,7 +476,8 @@ function csar.eventHandler:onEvent(_event)
             end
         end
 
-        if _event.initiator:getName() and _event.initiator:getPlayerName() then
+        -- sometimes the "getPlayerName" function is not defined in the _event.initiator object (not a player unit) ; check for it.
+        if _event.initiator.getName and _event.initiator:getName() and _event.initiator.getPlayerName and _event.initiator:getPlayerName() then
 
             csar.logInfo("Checking Unit - " .. _event.initiator:getName())
             csar.checkDisabledAircraftStatus({ _event.initiator:getName(), _event.initiator:getPlayerName() })


### PR DESCRIPTION
(see my other PR for CTLD [here](https://github.com/ciribob/DCS-CTLD/pull/93)).

There is no more a need to restart transmissions every 30 seconds, as the bug has been corrected (see [here](https://forum.dcs.world/topic/276106-arc-frequencies/page/2/)).

Instead, I made changes to create the transmissions once, with a unique name (now mandatory, see [here](https://forum.dcs.world/topic/316378-placed-adf-beacons-only-transmit-briefly/)) and the "loop" parameter activated.

Then, every minute, the stopBeaconIfNeeded function checks if the wounded group is still in the field, and stops then beacon transmission if they are not.

I tested that in solo (multiplayer not yet tested, although the same code has been tested in MP with CTLD):

- had an A-10 eject and set a Huey's radio to hear the beacon
- wait for the wounded pilot to climb aboard and verify that the beacon turned off